### PR TITLE
fix(DevelopersDoc) url syntax update woocommerce logs

### DIFF
--- a/docs/ecommerce/woocommerce/__components__/woocommerce-advanced-settings.mdx
+++ b/docs/ecommerce/woocommerce/__components__/woocommerce-advanced-settings.mdx
@@ -59,8 +59,8 @@ Após esta alteração os novos pedidos quando forem pagos irão receber o valor
 Você pode visualizar os logs OpenPix em sua loja através dos seguintes passos:
 
 - 1. Tenha acesso aos arquivos da loja
-- 2. Acesse o seguinte path: `/wp-content/uploads/wc_logs`
-- 3. Dentro de `wc_logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
+- 2. Acesse o seguinte path: `/wp-content/uploads/wc-logs`
+- 3. Dentro de `wc-logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
 
 ## 7. Como verificar se o HPOS está habilitado?
 

--- a/docs/ecommerce/woocommerce/woocommerce-crediary.mdx
+++ b/docs/ecommerce/woocommerce/woocommerce-crediary.mdx
@@ -91,5 +91,5 @@ Pague a entrada via Pix usando o app do seu banco:
 Você pode visualizar os logs OpenPix em sua loja através dos seguintes passos:
 
 - 1. Tenha acesso aos arquivos da loja
-- 2. Acesse o seguinte path: `/wp-content/uploads/wc_logs`
-- 3. Dentro de `wc_logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
+- 2. Acesse o seguinte path: `/wp-content/uploads/wc-logs`
+- 3. Dentro de `wc-logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`

--- a/docs/ecommerce/woocommerce/woocommerce-parcelado.mdx
+++ b/docs/ecommerce/woocommerce/woocommerce-parcelado.mdx
@@ -152,6 +152,6 @@ Após esta alteração os novos pedidos quando forem pagos irão receber o valor
 Você pode visualizar os logs OpenPix em sua loja através dos seguintes passos:
 
 - 1. Tenha acesso aos arquivos da loja
-- 2. Acesse o seguinte path: `/wp-content/uploads/wc_logs`
-- 3. Dentro de `wc_logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
+- 2. Acesse o seguinte path: `/wp-content/uploads/wc-logs`
+- 3. Dentro de `wc-logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/ecommerce/woocommerce/woocommerce-plugin.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ecommerce/woocommerce/woocommerce-plugin.md
@@ -109,5 +109,5 @@ Após esta alteração os novos pedidos quando forem pagos irão receber o valor
 Você pode visualizar os logs OpenPix em sua loja através dos seguintes passos:
 
 - 1. Tenha acesso aos arquivos da loja
-- 2. Acesse o seguinte path: `/wp-content/uploads/wc_logs`
-- 3. Dentro de `wc_logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`
+- 2. Acesse o seguinte path: `/wp-content/uploads/wc-logs`
+- 3. Dentro de `wc-logs` você irá encontrar os arquivos de logs da openpix com o seguinte padrão de nome `woocommerce_openpix-2023-01-13-7d609d821235742dd8162bbb0ef84862`


### PR DESCRIPTION
Updating the way to retrieve logs from our plugin with woocommerce

![image](https://github.com/user-attachments/assets/e36435ed-98fc-4353-b19f-030e60beda5d)
